### PR TITLE
PDT24-50 | Configure REST API versioning

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from '@/app.module';
 import { WinstonModule } from 'nest-winston';
 import { loggerConfig } from '@/config/logger.config';
-import { Logger } from '@nestjs/common';
+import { Logger, VersioningType } from '@nestjs/common';
 import { env } from '@/config/env.config';
 import { redisClient } from '@/config/redis.config';
 
@@ -16,6 +16,12 @@ async function bootstrap(): Promise<void> {
 
 		await redisClient.connect();
 		logger.log('Connected to Redis');
+
+		app.setGlobalPrefix('api');
+		app.enableVersioning({
+			type: VersioningType.URI,
+			defaultVersion: '1',
+		});
 
 		await app.listen(port, () => {
 			logger.log(`App is listening on port ${port}`);


### PR DESCRIPTION
### Tasks

- [Configure REST API versioning](https://outsidetech.atlassian.net/browse/PDT24-50)

### Changes

- [x] Setup global prefix and  enabled app versioning with version type uri in main.ts file.

### Notes

- Now by default, all the API endpoints are prefixed with /api/v1/. Now we can have different versions for different endpoints. Refer to [the official docs](https://docs.nestjs.com/techniques/versioning#usage) on how to use versioning. 
