### PR TITLE
PDT24-97 | Add filtration for analytical data by various query params

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { AllExceptionsFilter } from '@/core/all-exceptions.filter';
 import { MailerModule } from '@/mailer/mailer.module';
 import { LoggerModule } from '@/logger/logger.module';
 import { ShortUrlsModule } from '@/short-urls/short-urls.module';
+import { UrlAnalyticsModule } from '@/url-analytics/url-analytics.module';
 @Module({
 	imports: [
 		ConfigModule.forRoot({ isGlobal: true, validate }),
@@ -22,6 +23,7 @@ import { ShortUrlsModule } from '@/short-urls/short-urls.module';
 		MailerModule,
 		ShortUrlsModule,
 		LoggerModule,
+		UrlAnalyticsModule,
 	],
 	controllers: [AppController],
 	providers: [

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -3,8 +3,10 @@ export const successMessage = {
 	userFetched: 'User has been fetched successfully',
 	userVerified: 'User has been verified successfully',
 	verificationEmailSent: 'Verification Email has been sent successfully',
-	shortUrlCreated: 'Short URL created successfylly',
+	shortUrlCreated: 'Short URL created successfully',
 	loginSuccess: 'Login success',
+	redirectionLogsSuccessful: 'Redirection logs created successfully',
+	fetchedAnalytics: 'Redirection logs for given user has been fetched',
 };
 
 export const errorMessage = {

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -25,4 +25,5 @@ export const errorMessage = {
 	urlCreationFailure: 'Short URL not created',
 	authenticationFailed: 'Could not authenticate user. Has the session expired?',
 	shortCodeGenerationFailed: 'Failed to generate unique URL code after maximum retries',
+	queryDateValidation: 'Provided query endDate must be greater than startDate',
 };

--- a/src/common/response.interface.ts
+++ b/src/common/response.interface.ts
@@ -1,3 +1,5 @@
+import { UrlAnalytics } from '@/url-analytics/entities/url-analytics.entity';
+
 export interface SuccessResponse {
 	status: number;
 	message: string;
@@ -16,3 +18,7 @@ export type TemplateResponse = {
 	data: string;
 };
 
+export type QueryFilterInterface = {
+	reports: UrlAnalytics[];
+	numberOfHits?: number;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ async function bootstrap(): Promise<void> {
 		logger.log('Connected to Redis');
 
 		app.setGlobalPrefix('api', {
-			exclude: [{ path: ':shortCode', method: RequestMethod.GET }],
+			exclude: [{ path: 'urls/:shortCode', method: RequestMethod.GET }],
 		});
 		app.enableVersioning({
 			type: VersioningType.URI,

--- a/src/short-urls/short-urls.controller.ts
+++ b/src/short-urls/short-urls.controller.ts
@@ -21,7 +21,7 @@ import { Request, Response } from 'express';
 import { successMessage } from '@/common/messages';
 import { Avoid } from '@/decorator/avoid-guard.decorator';
 @UseGuards(AuthGuard)
-@Controller()
+@Controller('urls')
 export class ShortUrlsController {
 	constructor(private readonly shortUrlsService: ShortUrlsService) {}
 	@Post()

--- a/src/url-analytics/dto/create-analytics.dto.ts
+++ b/src/url-analytics/dto/create-analytics.dto.ts
@@ -1,7 +1,18 @@
+import { IsString } from 'class-validator';
+
 export class CreateUrlAnalyticsDto {
+	@IsString()
 	shortUrlId: string;
+
+	@IsString()
 	userId: string;
+
+	@IsString()
 	ipAddress: string;
+
+	@IsString()
 	userAgent: string;
+
+	@IsString()
 	shortURL: string;
 }

--- a/src/url-analytics/dto/query-analytics.dto.ts
+++ b/src/url-analytics/dto/query-analytics.dto.ts
@@ -1,13 +1,19 @@
-import { IsOptional, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsDate, IsOptional, IsString, MaxDate, Validate } from 'class-validator';
+import { FilterDate } from '@/url-analytics/validator/filter-date.validator';
 
 export class AnalyticsQueryDto {
-	@IsString()
+	@IsDate()
 	@IsOptional()
-	from: string;
+	@Transform(({ value }) => new Date(value), { toClassOnly: true })
+	startDate: Date;
 
-	@IsString()
+	@IsDate()
 	@IsOptional()
-	to: string;
+	@Transform(({ value }) => new Date(value), { toClassOnly: true })
+	@MaxDate(new Date())
+	@Validate(FilterDate)
+	endDate: Date;
 
 	@IsString()
 	@IsOptional()
@@ -29,7 +35,12 @@ export class AnalyticsQueryDto {
 	@IsOptional()
 	groupBy: string;
 
+	@IsDate()
+	@IsOptional()
+	@Transform(({ value }) => new Date(value), { toClassOnly: true })
+	clickedAt: Date;
+
 	@IsString()
 	@IsOptional()
-	clicked_at: string;
+	urlId: string;
 }

--- a/src/url-analytics/dto/query-analytics.dto.ts
+++ b/src/url-analytics/dto/query-analytics.dto.ts
@@ -37,7 +37,7 @@ export class AnalyticsQueryDto {
 	@IsOptional()
 	country: string;
 
-	@IsEnum(GroupByAndSortBY)
+	@IsString()
 	@IsOptional()
 	groupBy: string;
 

--- a/src/url-analytics/dto/query-analytics.dto.ts
+++ b/src/url-analytics/dto/query-analytics.dto.ts
@@ -1,0 +1,35 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class AnalyticsQueryDto {
+	@IsString()
+	@IsOptional()
+	from: string;
+
+	@IsString()
+	@IsOptional()
+	to: string;
+
+	@IsString()
+	@IsOptional()
+	browser: string;
+
+	@IsString()
+	@IsOptional()
+	device: string;
+
+	@IsString()
+	@IsOptional()
+	os: string;
+
+	@IsString()
+	@IsOptional()
+	country: string;
+
+	@IsString()
+	@IsOptional()
+	groupBy: string;
+
+	@IsString()
+	@IsOptional()
+	clicked_at: string;
+}

--- a/src/url-analytics/dto/query-analytics.dto.ts
+++ b/src/url-analytics/dto/query-analytics.dto.ts
@@ -2,7 +2,7 @@ import { Transform } from 'class-transformer';
 import { IsDate, IsEnum, IsOptional, IsString, MaxDate, Validate } from 'class-validator';
 import { FilterDate } from '@/url-analytics/validator/filter-date.validator';
 
-enum GroupByAndSortBY {
+enum GroupByAndSortBy {
 	operating_system = 'operating_system',
 	device = 'device',
 	browser = 'browser',
@@ -56,7 +56,7 @@ export class AnalyticsQueryDto {
 	@IsOptional()
 	limit?: number;
 
-	@IsEnum(GroupByAndSortBY)
+	@IsEnum(GroupByAndSortBy)
 	@IsOptional()
 	sortBy?: string;
 

--- a/src/url-analytics/dto/query-analytics.dto.ts
+++ b/src/url-analytics/dto/query-analytics.dto.ts
@@ -1,7 +1,13 @@
 import { Transform } from 'class-transformer';
-import { IsDate, IsOptional, IsString, MaxDate, Validate } from 'class-validator';
+import { IsDate, IsEnum, IsOptional, IsString, MaxDate, Validate } from 'class-validator';
 import { FilterDate } from '@/url-analytics/validator/filter-date.validator';
 
+enum GroupByAndSortBY {
+	operating_system = 'operating_system',
+	device = 'device',
+	browser = 'browser',
+	clicked_at = 'clicked_at',
+}
 export class AnalyticsQueryDto {
 	@IsDate()
 	@IsOptional()
@@ -31,7 +37,7 @@ export class AnalyticsQueryDto {
 	@IsOptional()
 	country: string;
 
-	@IsString()
+	@IsEnum(GroupByAndSortBY)
 	@IsOptional()
 	groupBy: string;
 
@@ -50,7 +56,7 @@ export class AnalyticsQueryDto {
 	@IsOptional()
 	limit?: number;
 
-	@IsString()
+	@IsEnum(GroupByAndSortBY)
 	@IsOptional()
 	sortBy?: string;
 

--- a/src/url-analytics/dto/query-analytics.dto.ts
+++ b/src/url-analytics/dto/query-analytics.dto.ts
@@ -43,4 +43,16 @@ export class AnalyticsQueryDto {
 	@IsString()
 	@IsOptional()
 	urlId: string;
+
+	@IsOptional()
+	page?: number;
+
+	@IsOptional()
+	limit?: number;
+
+	@IsString()
+	@IsOptional()
+	sortBy?: string;
+
+	order?: 'ASC' | 'DESC';
 }

--- a/src/url-analytics/url-analytics.controller.ts
+++ b/src/url-analytics/url-analytics.controller.ts
@@ -1,18 +1,19 @@
 import { AuthGuard } from '@/auth/guard/auth.guard';
 import { User } from '@/users/entities/user.entity';
-import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
 import { Request } from 'express';
 import { UrlAnalyticsService } from '@/url-analytics/url-analytics.service';
 import { UrlAnalytics } from '@/url-analytics/entities/url-analytics.entity';
+import { AnalyticsQueryDto } from '@/url-analytics/dto/query-analytics.dto';
 
 @Controller('reports')
 export class UrlAnalyticsController {
 	constructor(private readonly analyticsService: UrlAnalyticsService) {}
 	@UseGuards(AuthGuard)
 	@Get()
-	async generateReportForUser(@Req() req: Request): Promise<UrlAnalytics[]> {
+	async generateReportForUser(@Query() query: AnalyticsQueryDto, @Req() req: Request): Promise<UrlAnalytics[]> {
 		const { id } = req.user as User;
-		const reports = await this.analyticsService.getUserSpecificAnalysis(id);
+		const reports = await this.analyticsService.getUserSpecificAnalysis(id, query);
 		return reports;
 	}
 }

--- a/src/url-analytics/url-analytics.controller.ts
+++ b/src/url-analytics/url-analytics.controller.ts
@@ -3,15 +3,15 @@ import { User } from '@/users/entities/user.entity';
 import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
 import { Request } from 'express';
 import { UrlAnalyticsService } from '@/url-analytics/url-analytics.service';
-import { UrlAnalytics } from '@/url-analytics/entities/url-analytics.entity';
 import { AnalyticsQueryDto } from '@/url-analytics/dto/query-analytics.dto';
+import { QueryFilterInterface } from '@/common/response.interface';
 
 @Controller('reports')
 export class UrlAnalyticsController {
 	constructor(private readonly analyticsService: UrlAnalyticsService) {}
 	@UseGuards(AuthGuard)
 	@Get()
-	async generateReportForUser(@Query() query: AnalyticsQueryDto, @Req() req: Request): Promise<UrlAnalytics[]> {
+	async generateReportForUser(@Query() query: AnalyticsQueryDto, @Req() req: Request): Promise<QueryFilterInterface> {
 		const { id } = req.user as User;
 		const reports = await this.analyticsService.getUserSpecificAnalysis(id, query);
 		return reports;

--- a/src/url-analytics/url-analytics.service.ts
+++ b/src/url-analytics/url-analytics.service.ts
@@ -7,6 +7,7 @@ import { CreateUrlAnalyticsDto } from '@/url-analytics/dto/create-analytics.dto'
 import { lookup } from 'geoip-country';
 import { UAParser } from 'ua-parser-js';
 import { AnalyticsQueryDto } from '@/url-analytics/dto/query-analytics.dto';
+import { successMessage } from '@/common/messages';
 
 @Injectable()
 export class UrlAnalyticsService {
@@ -32,21 +33,16 @@ export class UrlAnalyticsService {
 				operating_system: os?.toLowerCase(),
 				country,
 			};
-			const redirectionLogs = await this.analyticsRepo.insert(analytics);
-			console.log(redirectionLogs);
+			await this.analyticsRepo.insert(analytics);
+			this.logger.log(successMessage.redirectionLogsSuccessful);
 		} catch (error) {
-			console.log(error);
+			this.logger.error(error);
 			return;
 		}
 	}
 
 	async getUserSpecificAnalysis(userId: string, query: AnalyticsQueryDto): Promise<UrlAnalytics[]> {
 		const { from, to, browser, device, os, groupBy, clicked_at } = query;
-		const fromDate = new Date(from);
-		const toDate = new Date(to);
-		const clickedAtDate = new Date(clicked_at);
-		const eod = new Date(clicked_at);
-		eod.setDate(eod.getDate() + 1);
 		const queryBuilder = this.analyticsRepo
 			.createQueryBuilder('redirection_logs')
 			.select([
@@ -59,38 +55,46 @@ export class UrlAnalyticsService {
 				`redirection_logs.browser AS browser`,
 			])
 			.where('user_id = :userId', { userId });
-		if (from && to) {
-			queryBuilder.andWhere('redirection_logs.clicked_at >= :from AND redirection_logs.clicked_at <= :to', {
-				from: fromDate,
-				to: toDate,
+		if (from || to) {
+			queryBuilder.andWhere('redirection_logs.clicked_at BETWEEN :from AND :to', {
+				from: from ? new Date(from) : new Date(0),
+				to: to ? new Date(to) : new Date(),
 			});
 		}
-		if (from) queryBuilder.andWhere('redirection_logs.clicked_at >= :from', { from: fromDate });
-		if (to) queryBuilder.andWhere('redirection_logs.clicked_at <= :to', { to: toDate });
 		if (device) queryBuilder.andWhere('redirection_logs.device = :device', { device });
 		if (browser) queryBuilder.andWhere('redirection_logs.browser = :browser', { browser });
 		if (os) queryBuilder.andWhere('redirection_logs.operating_system = :device', { os });
-		if (clicked_at)
+		if (clicked_at) {
+			const clickedAtDate = new Date(clicked_at);
+			const eod = new Date(clicked_at);
+			eod.setDate(eod.getDate() + 1);
 			queryBuilder.andWhere('redirection_logs.clicked_at >= :clickedAtDate AND redirection_logs.clicked_at < :eod', {
 				clickedAtDate,
 				eod,
 			});
+		}
+
 		if (groupBy) {
-			if (groupBy == 'clicked_at') {
-				queryBuilder
-					.select([
-						`DATE(redirection_logs.${groupBy}) AS ${groupBy} `,
-						`COUNT(redirection_logs.${groupBy}) AS numberOfHits`,
-					])
-					.groupBy(`DATE(redirection_logs.${groupBy})`);
-			} else {
-				queryBuilder
-					.select([`redirection_logs.${groupBy} AS ${groupBy} `, `COUNT(redirection_logs.${groupBy}) AS numberOfHits`])
-					.groupBy(`redirection_logs.${groupBy} `);
+			switch (groupBy) {
+				case 'clicked_at':
+					queryBuilder
+						.select([
+							`DATE(redirection_logs.${groupBy}) AS ${groupBy} `,
+							`COUNT(redirection_logs.${groupBy}) AS numberOfHits`,
+						])
+						.groupBy(`DATE(redirection_logs.${groupBy})`);
+					break;
+				default:
+					queryBuilder
+						.select([
+							`redirection_logs.${groupBy} AS ${groupBy} `,
+							`COUNT(redirection_logs.${groupBy}) AS numberOfHits`,
+						])
+						.groupBy(`redirection_logs.${groupBy} `);
 			}
 		}
 		const reports = await queryBuilder.getRawMany();
-
+		this.logger.log(successMessage.fetchedAnalytics);
 		return reports;
 	}
 
@@ -109,7 +113,6 @@ export class UrlAnalyticsService {
 
 	private async getCountryFromIP(ip: string): Promise<string | undefined> {
 		const location = lookup(ip);
-		console.log(location);
 		return location?.country;
 	}
 }

--- a/src/url-analytics/url-analytics.service.ts
+++ b/src/url-analytics/url-analytics.service.ts
@@ -35,7 +35,21 @@ export class UrlAnalyticsService {
 	}
 
 	async getUserSpecificAnalysis(userId: string, query: AnalyticsQueryDto): Promise<UrlAnalytics[]> {
-		const { startDate, endDate, browser, device, os, groupBy, clickedAt, country, urlId } = query;
+		const {
+			startDate,
+			endDate,
+			browser,
+			device,
+			os,
+			groupBy,
+			clickedAt,
+			country,
+			urlId,
+			page = 1,
+			limit = 10,
+			sortBy = 'clicked_at',
+			order = 'DESC',
+		} = query;
 		const queryBuilder = this.analyticsRepo
 			.createQueryBuilder('logs')
 			.leftJoin('logs.short_url', 'shortUrl')
@@ -103,6 +117,10 @@ export class UrlAnalyticsService {
 				}
 			}
 		}
+		queryBuilder.orderBy(`logs.${sortBy}`, order);
+		const skip = (page - 1) * limit;
+		queryBuilder.skip(skip).limit(limit);
+
 		const reports = await queryBuilder.getRawMany();
 		this.logger.log(successMessage.fetchedAnalytics);
 		return reports;

--- a/src/url-analytics/url-analytics.service.ts
+++ b/src/url-analytics/url-analytics.service.ts
@@ -12,8 +12,8 @@ import { LoggerService } from '@/logger/logger.service';
 @Injectable()
 export class UrlAnalyticsService {
 	constructor(
-		@InjectRepository(UrlAnalytics)
 		private logger: LoggerService,
+		@InjectRepository(UrlAnalytics)
 		private analyticsRepo: Repository<UrlAnalytics>,
 	) {}
 
@@ -49,7 +49,7 @@ export class UrlAnalyticsService {
 			])
 			.where('user_id = :userId', { userId });
 		if (from || to) {
-			queryBuilder.andWhere('redirection_logs.clicked_at BETWEEN :from AND :to', {
+			queryBuilder.andWhere('DATE(redirection_logs.clicked_at) BETWEEN :from AND :to', {
 				from: from ? new Date(from) : new Date(0),
 				to: to ? new Date(to) : new Date(),
 			});

--- a/src/url-analytics/url-analytics.service.ts
+++ b/src/url-analytics/url-analytics.service.ts
@@ -110,7 +110,6 @@ export class UrlAnalyticsService {
 		queryBuilder.skip(skip).limit(limit);
 
 		const reports = await queryBuilder.getRawMany();
-		console.log(reports);
 		this.logger.log(successMessage.fetchedAnalytics);
 		return reports;
 	}
@@ -134,7 +133,7 @@ export class UrlAnalyticsService {
 	}
 
 	private async parseQuerytoArray(queryKey: string): Promise<string[]> {
-		const queryKeyArray: string[] = queryKey.includes(',') ? queryKey.split(',') : [queryKey];
+		const queryKeyArray: string[] = queryKey.split(',');
 		return queryKeyArray;
 	}
 
@@ -142,15 +141,14 @@ export class UrlAnalyticsService {
 		queryBuilder: SelectQueryBuilder<UrlAnalytics>,
 		grpByArr: string[],
 	): Promise<void> {
-		console.log(grpByArr);
 		queryBuilder.select(`COUNT(logs.id) AS numberOfHits`);
-		for (let i = 0; i < grpByArr.length; i++) {
-			switch (grpByArr[i]) {
+		for (const field of grpByArr) {
+			switch (field) {
 				case 'clicked_at':
 					queryBuilder.addSelect(['DATE(logs.clicked_at) AS "clickedAt"']).addGroupBy('DATE(logs.clicked_at)');
 					break;
 				default:
-					queryBuilder.addSelect([`logs.${grpByArr[i]} AS ${grpByArr[i]} `]).addGroupBy(`logs.${grpByArr[i]} `);
+					queryBuilder.addSelect([`logs.${field} AS ${field} `]).addGroupBy(`logs.${field} `);
 			}
 		}
 		return;

--- a/src/url-analytics/url-analytics.service.ts
+++ b/src/url-analytics/url-analytics.service.ts
@@ -106,7 +106,7 @@ export class UrlAnalyticsService {
 
 			for (let i = 0; i < grpByArr.length; i++) {
 				switch (grpByArr[i]) {
-					case 'clickedAt':
+					case 'clicked_at':
 						queryBuilder
 							.addSelect([`DATE(logs.${grpByArr[i]}) AS ${grpByArr[i]} `])
 							.addGroupBy(`DATE(logs.${grpByArr[i]})`);
@@ -116,8 +116,9 @@ export class UrlAnalyticsService {
 						queryBuilder.addSelect([`logs.${grpByArr[i]} AS ${grpByArr[i]} `]).addGroupBy(`logs.${grpByArr[i]} `);
 				}
 			}
+		} else {
+			queryBuilder.orderBy(`logs.${sortBy}`, order);
 		}
-		queryBuilder.orderBy(`logs.${sortBy}`, order);
 		const skip = (page - 1) * limit;
 		queryBuilder.skip(skip).limit(limit);
 

--- a/src/url-analytics/validator/filter-date.validator.ts
+++ b/src/url-analytics/validator/filter-date.validator.ts
@@ -1,5 +1,6 @@
 import { ValidatorConstraint, ValidationArguments, ValidatorConstraintInterface } from 'class-validator';
 import { AnalyticsQueryDto } from '@/url-analytics/dto/query-analytics.dto';
+import { errorMessage } from '@/common/messages';
 
 @ValidatorConstraint({ name: 'FilterDate', async: false })
 export class FilterDate implements ValidatorConstraintInterface {
@@ -10,6 +11,6 @@ export class FilterDate implements ValidatorConstraintInterface {
 	}
 
 	defaultMessage(): string {
-		return `endDate must be greater than startDate`;
+		return errorMessage.queryDateValidation;
 	}
 }

--- a/src/url-analytics/validator/filter-date.validator.ts
+++ b/src/url-analytics/validator/filter-date.validator.ts
@@ -1,0 +1,15 @@
+import { ValidatorConstraint, ValidationArguments, ValidatorConstraintInterface } from 'class-validator';
+import { AnalyticsQueryDto } from '@/url-analytics/dto/query-analytics.dto';
+
+@ValidatorConstraint({ name: 'FilterDate', async: false })
+export class FilterDate implements ValidatorConstraintInterface {
+	validate(endDate: Date, args: ValidationArguments): boolean {
+		const { startDate } = args.object as AnalyticsQueryDto;
+		if (!startDate || !endDate) return true;
+		return endDate >= startDate;
+	}
+
+	defaultMessage(): string {
+		return `endDate must be greater than startDate`;
+	}
+}


### PR DESCRIPTION
### Tasks

- [Add filtration for analytical data by various query params](https://outsidetech.atlassian.net/browse/PDT24-97)
- [Add pagination , sorting and limitation](https://outsidetech.atlassian.net/browse/PDT24-99)

### Changes

- [x] Create an endpoint for making filtration on redirection logs based on various query params. 

### Notes
The url with the query params looks quite like this:
`{{url}}/api/v1/reports?startDate=2025-01-26&endDate=2025-01 26&browser=Chrome,Firefox&device=Tablet,Desktop&os=Linux&urlId=7282c39e-fe94-4455-b6f4-305205c77a85&sortBy=operating_system&order=ASC&page=1&limit=5`