### PR TITLE
PDT24-106 | Add rate limiting in URL redirection endpoint

### DIFF
--- a/src/config/rateLimit.config.ts
+++ b/src/config/rateLimit.config.ts
@@ -11,4 +11,5 @@ export const otpVerificationRateLimiter = {
 export const urlRateLimiter = {
 	max: 5,
 	windowMs: 1 * 60,
+	isGlobal: true,
 };

--- a/src/middleware/rate-limit.middleware.ts
+++ b/src/middleware/rate-limit.middleware.ts
@@ -8,6 +8,7 @@ import { redisClient } from '@/config/redis.config';
 interface RateLimitConfig {
 	windowMs: number;
 	max: number;
+	isGlobal?: boolean;
 }
 
 @Injectable()
@@ -24,6 +25,7 @@ export class RateLimitMiddlewareFactory {
 					message: 'Too many requests from this IP, please try again later.',
 				},
 				standardHeaders: true,
+				...(config.isGlobal ? { keyGenerator: () => `global-limit` } : {}),
 				legacyHeaders: false,
 				validate: { xForwardedForHeader: false },
 				store: new RedisStore({

--- a/src/short-urls/short-urls.module.ts
+++ b/src/short-urls/short-urls.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule, RequestMethod } from '@nestjs/common';
 import { ShortUrlsService } from '@/short-urls/short-urls.service';
 import { ShortUrlsController } from '@/short-urls/short-urls.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -7,6 +7,8 @@ import { UsersModule } from '@/users/users.module';
 import { BullModule } from '@nestjs/bullmq';
 import { ExpiryEmailConsumer } from '@/queue/queue.consumer';
 import { MailerModule } from '@/mailer/mailer.module';
+import { RateLimitMiddlewareFactory } from '@/middleware/rate-limit.middleware';
+import { urlRateLimiter } from '@/config/rateLimit.config';
 
 @Module({
 	imports: [
@@ -19,4 +21,10 @@ import { MailerModule } from '@/mailer/mailer.module';
 	providers: [ShortUrlsService, ExpiryEmailConsumer],
 	exports: [ShortUrlsService],
 })
-export class ShortUrlsModule {}
+export class ShortUrlsModule implements NestModule {
+	configure(consumer: MiddlewareConsumer): void {
+		consumer
+			.apply(RateLimitMiddlewareFactory.create(urlRateLimiter))
+			.forRoutes({ path: '/s/:shortCode', method: RequestMethod.GET });
+	}
+}


### PR DESCRIPTION
### Tasks

- [Add rate limiting in URL redirection endpoint](https://outsidetech.atlassian.net/browse/PDT24-106)

### Changes

- [x] Added keyGenerator property in rate limit config when isGlobal config is passed to set global rate limit where used.
- [x] Updated rate limit config for url redirection: added isGlobal: true to apply global rate limiting in /s/:shortCode endpoint 
